### PR TITLE
[ADD] ability to run external program

### DIFF
--- a/PirModels/__init__.py
+++ b/PirModels/__init__.py
@@ -1,0 +1,1 @@
+from PirModels.mfannot_external_progs import MFannotExternalProgs

--- a/PirModels/masterfile/__init__.py
+++ b/PirModels/masterfile/__init__.py
@@ -1,0 +1,1 @@
+from .masterfile import Masterfile

--- a/PirModels/masterfile/annot_pair.py
+++ b/PirModels/masterfile/annot_pair.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+class AnnotPair:
+    # __init__ with all the attributes optional
+    def __init__(self, type=None, genename=None, startpos=None, endpos=None, direction=None, startline=None, endline=None, startmulticomment=None, endmulticomment=None, startlinenumber=None, endlinenumber=None, introntype=None, globaltype=None):
+        self.type              = type
+        self.genename          = genename
+        self.startpos          = startpos
+        self.endpos            = endpos
+        self.direction         = direction
+        self.startline         = startline
+        self.endline           = endline
+        self.startmulticomment = startmulticomment
+        self.endmulticomment   = endmulticomment
+        self.startlinenumber   = startlinenumber
+        self.endlinenumber     = endlinenumber
+        self.introntype        = introntype
+        self.globaltype        = globaltype

--- a/PirModels/masterfile/masterfile.py
+++ b/PirModels/masterfile/masterfile.py
@@ -1,0 +1,693 @@
+#!/usr/bin/env python3
+
+from pprint import pprint
+
+from masterfile_contig import MasterfileContig
+from annot_pair        import AnnotPair
+
+import functools
+import re
+
+#####################################################################
+# Utility functions                                                 #
+#####################################################################
+
+# This is a Python implementation of the Perl cmp function
+def cmp(a, b):
+    return (a > b) - (a < b) # return 1 if a > b, -1 if a < b, 0 otherwise
+
+def sort_annots(a, b):
+    # Modified by T. HOELLINGER
+
+    # Simple case, nucleotide position is different:
+    if a[0] != b[0]:
+        return cmp(a[0], b[0])
+
+    # Simple case, line numbers are available and > 0, so compare them
+    if a[1] and b[1]:
+        return cmp(a[1], b[1])
+
+    # The new sorting function
+    fulllinea   = " "; # G-genname ==> start ;; comment
+    fulllineb   = " "; #    ||     ||
+    namea       = " "; # the genename
+    nameb       = " "; #   ||    ||
+    arrowa      = " "; # ==> or <==
+    arrowb      = " "; #  ||    ||
+    startorenda = " "; # as it said start or end
+    startorendb = " "; #         ||      ||
+
+    if a[2] == "S":
+        fulllinea = a[3].startline
+    if a[2] == "E":
+        fulllinea = a[3].endline
+    if b[2] == "S":
+        fulllineb = b[3].startline
+    if b[2] == "E":
+        fulllineb = b[3].endline
+
+    #  Cut the line were there are ;;
+    cutlinea = fulllinea.split(";;")
+    cutlineb = fulllineb.split(";;")
+
+    #  Cut the line and identify pattern
+    # Only take the part before ;;, Delete comments
+    linea = cutlinea[0] or ""
+    #     ||        ||
+    lineb = cutlineb[0] or ""
+
+    linea = linea.strip()  # Delete the spaces before, at the beginning of the description
+    lineb = lineb.strip()  #     ||        ||
+    linea = linea.rstrip() # Delete the spaces at the end of the descriptio
+    lineb = lineb.rstrip() #     ||        ||
+
+    linea       = re.match(r'([\w|\_\-\d\(\)\?]+)\s*(==>|<==)\s*(start|end)', linea)
+    namea       = linea.group(1) or "" # Get the genename
+    arrowa      = linea.group(2) or "" # Ge                                            IsDef = 1 if not char else 0 "" # Get the start or the end
+
+    lineb = re.match(r'([\w|\_\-\d\(\)\?]+)\s*(==>|<==)\s*(start|end)', lineb)
+    nameb = lineb.group(1)       or ""
+    arrowb = lineb.group(2)      or ""
+    startorendb = lineb.group(3) or ""
+
+    if arrowa == "==>" and arrowb == "==>" and startorenda == "start" and startorendb == "start":
+        return cmp(namea, nameb)
+    elif arrowa == "==>" and arrowb == "==>" and startorenda == "end" and startorendb == "end":
+        return cmp(nameb, namea)
+    elif arrowa == "==>" and arrowb == "==>" and startorenda == "start" and startorendb == "end":
+        return cmp(a[2], b[2])  # end before the start
+    elif arrowa == "==>" and arrowb == "==>" and startorenda == "end" and startorendb == "start":
+        return cmp(a[2], b[2])  # end before the start
+    elif arrowa == "<==" and arrowb == "<==" and startorenda == "start" and startorendb == "start":
+        return cmp(nameb, namea)
+    elif arrowa == "<==" and arrowb == "<==" and startorenda == "end" and startorendb == "end":
+        return cmp(namea, nameb)
+    elif arrowa == "<==" and arrowb == "<==" and startorenda == "start" and startorendb == "end":
+        return cmp(b[2], a[2])  # start before the end
+    elif arrowa == "<==" and arrowb == "<==" and startorenda == "end" and startorendb == "start":
+        return cmp(b[2], a[2])  # start before the end
+    else:
+        return cmp(fulllinea, fulllineb)
+
+
+# Print the sequence in fasta format X characters per line
+def fasta_block_to_fh(seq, pos, fh):
+    while seq:
+        if len(seq) > 60:
+            subseq = seq[:60]
+            fh.write(f"{pos:6d}  {subseq}\n")
+            pos += len(re.findall(r'[acgtACGTnN]', subseq))
+            seq = seq[60:]
+            continue
+        fh.write(f"{pos:6d}  {seq}\n")
+        break
+
+def remove_AP(AP_to_rm=[],contig=MasterfileContig()):
+
+    all_annots = contig.annotations
+    for i in range(len(all_annots) - 1, -1, -1):
+        contig_AP = all_annots[i]
+        id_contig_AP = id(contig_AP)
+
+        # go over the table containing annotation
+        for id_rm_AP in AP_to_rm:
+            # It mean start is already defined
+            if id_rm_AP == id_contig_AP:
+                all_annots.remove(contig_AP)
+
+
+
+#####################################################################
+# Masterfile class:                                                 #
+#                                                                   #
+# This class represents a masterfile.                               #
+#####################################################################
+
+class Masterfile:
+    def __init__(self):
+        self.masterfile = None
+        self.filename   = None
+        self.header     = []
+        self.comment    = None
+        self.contigs    = None
+
+
+    def clean_pirmaster(self, tmpdir=None):
+        AP_to_rm = []
+
+        # Check each annot push all annot to remove on $AP_to_rm, changed the other one
+        isUnique = {}
+        count    = 0
+        for contig in self.contigs:
+            annotations = contig.annotations
+
+            # print the number of annotations
+            # print("Number of annotations")
+            # print(len(annotations))
+            contigname  = contig.name
+            comments    = contig.namecomments or ""
+            header      = contigname + comments
+
+            if header in isUnique:
+                isUnique[header] += 1
+            else:
+                isUnique[header] = 1
+
+            if isUnique[header] > 1:
+                raise ValueError(f"Two contigs have same header '{header}'\n")
+
+            count += 1
+
+            # Clean name and comments
+            contig.name         = "contig" + str(count)
+            contig.namecomments = ""
+
+            seq                 = contig.sequence
+            seq                 = seq.replace("!", "")
+            seq                 = seq.upper()
+            contig.sequence     = seq
+            for annot_pair in annotations:
+                # Print annot_pair
+                type          = annot_pair.type
+                startline     = annot_pair.startline or ""
+                endline       = annot_pair.endline   or ""
+
+                new_startline = None
+                new_endline   = None
+
+                id_AP = id(annot_pair)
+
+                if type == "C":
+                    if startline and not startline.startswith(";; mfannot:"):
+                        continue
+                    if endline and not endline.startswith(";; mfannot:"):
+                        continue
+
+                annot_pair.type = "C"
+
+                if endline != None and startline != None:
+                    if not startline.startswith(";; mfannot:"):
+                        startline_match = re.match(r'(.+)\s*(;;.+)$', startline)
+                        if startline_match:
+                            if not re.search(r'mfannot:', startline_match.group(2)):
+                                new_startline        = startline_match.group(2)
+                                annot_pair.startline = new_startline
+                                if new_startline == "":
+                                    annot_pair.startpos = None
+
+                    if not endline.startswith(";; mfannot:"):
+                        endline_match = re.match(r'(.+)\s*(;;.+)$', endline)
+                        if endline_match:
+                            if not re.search(r'mfannot:', endline_match.group(2)):
+                                new_endline        = endline_match.group(2)
+                                annot_pair.endline = new_endline
+                                if new_endline == "":
+                                    annot_pair.endpos = None
+
+                    if new_startline == None and new_endline == None:
+                        AP_to_rm.append(id_AP)
+                        continue
+
+                elif endline == None:
+                    if startline.startswith(";; mfannot:"):
+                        AP_to_rm.append(id_AP)
+                        continue
+                    else:
+                        new_startline = ";$startline ;; mfannot: no end found"
+
+                    annot_pair.startline = new_startline
+                    continue
+                else:
+                    if endline.startswith(";; mfannot:"):
+                        AP_to_rm.append(id_AP)
+                        continue
+                    else:
+                        new_endline = ";$endline ;; mfannot: no start found"
+
+                    annot_pair.endline = new_endline
+                    continue
+
+        remove_AP(AP_to_rm, contig)
+        self.object_to_masterfile(f"{tmpdir}/Masterfile_copy")
+
+
+    def object_from_masterfile(self, filename, RemoveIupac=0):
+        self.filename = filename
+
+        with open(filename, 'r') as fh:
+            lines = fh.readlines()
+        lines = [line.strip() for line in lines]
+
+        row            = 0
+        header         = []
+        comment_header = []
+        after_header   = 0
+
+        while row < len(lines) and not lines[row].startswith('>'):
+            line = lines[row]
+            if line.startswith(';; end mfannot'):
+                row         += 1
+                after_header = 1
+                continue
+            if after_header == 0:
+                header.append(line)
+                row += 1
+            else:
+                comment_header.append(line)
+                row += 1
+
+        self.header   = header
+        MFheaderisDef = len(comment_header)
+        if MFheaderisDef == 0:
+            self.comment = header
+        else:
+            self.comment = comment_header
+
+        contigs = []
+        # Parse each contigs
+        while True:
+            if row >= len(lines):
+                break
+
+            contig = MasterfileContig()
+
+            line = lines[row]
+
+            row += 1
+            match = re.match(r'^>\s*(\S+)(.*)', line)
+            if not match:
+                raise ValueError(f"Can't parse header line of masterfile '{filename}'. Line is:\n{line}\n")
+            else:
+                faname       = match.group(1)
+                contig.name  = faname
+                namecomments = match.group(2)
+                # print(namecomments)
+                if namecomments != "" and re.match(r'/trans\s*=\s*(\d+)/i', namecomments):
+                    contig.geneticcode = namecomments.group(1)
+                if namecomments != "":
+                    contig.namecomments = namecomments
+
+            seq        = ""
+            annotexp   = {}
+            allannots  = []
+            seqpos     = 0 # in computer coordinates, not biological coordinates!
+            linenumber = 0
+
+            while row < len(lines):
+                linenumber += 1
+                line        = lines[row]
+                row        += 1
+
+                if not line.strip():
+                    continue
+                if line.startswith('>'):
+                    row -= 1
+                    break
+
+                match = re.match(r'^\s*\d*\s*([^;].*)', line)
+                if match:
+                    dna = match.group(1)
+                    if not dna.strip():
+                        continue  # ignore blank lines
+                    dna = dna.replace(" ", "").replace("\r", "").replace("\n", "").replace("\t", "")
+                    if RemoveIupac:
+                        if not re.match(r'^[acgtnN!]+$', dna):
+                            raise ValueError(f"Bad characters in sequence line?!??\nLine: {line}\n")
+                        seq    += dna  # includes special characters such as '!'
+                        seqpos += len(re.findall(r'[acgtACGTnN]', dna))  # count without the '!'s.
+                    else:
+                        if not re.match(r'^[uUyrwskmbdhvxUYRWSKMBDHVXACGTacgtnN!]+$', dna):
+                            raise ValueError(f"Bad characters in sequence line?!??\nLine: {line}\n")
+                        seq    += dna  # includes special characters such as '!'
+                        seqpos += len(re.findall(r'[uUyrwskmbdhvxUYRWSKMBDHVXacgtACGTnN]', dna))  # count without the '!'s.
+                        seq     = seq.translate(str.maketrans('uUyrwskmbdhvxUYRWSKMBDHVX', 'TTNNNNNNNNNNNNNNNNNNNNNNN'))
+                    continue
+
+                if re.match(r'^;\s*([G])-(\S+)\s+(<==\*?|\*?==>)\s+(start|end|point)(.*)', line):
+                    type, name, arrow, startend, comment = re.match(r'^;\s*([G])-(\S+)\s+(<==\*?|\*?==>)\s+(start|end|point)(.*)', line).groups()
+                    intron_type = re.search(r'/group=(\S+)', line).group(1) if re.search(r'/group=(\S+)', line) else ""
+
+                    multicomment = []
+                    while row < len(lines):
+                        if not line.startswith(';') or not lines[row-1].endswith('\\'):
+                            break
+                        multicomment.append(lines[row])
+                        row += 1
+
+                    pos = None
+                    if arrow == '>':
+                        if startend == 'start' or startend == 'point':
+                            pos = seqpos + 1
+                        else:
+                            pos = seqpos
+                    else:
+                        if startend == 'end':
+                            pos = seqpos + 1
+                        else:
+                            pos = seqpos
+
+                    annotkey = f"{type}-{name}".lower()
+
+                    ### structure of date : a hash called annotexp, contains a
+                    ### table. This one contains an other hash for storing annotation
+                    ### The last hash array has 3 keys :
+                    ### 1 -> start : if it's defined, start pos is defined in annotation
+                    ### 2 -> end : if it's defined, end pos is defined in annotation
+                    ### 3 -> annot : contains the annotation itself
+
+                    if startend == "point":
+                        # Create a new AnnotPair
+                        annot = AnnotPair(
+                            type       = type,
+                            introntype = intron_type,
+                            genename   = name,
+                            direction  = arrow
+                        )
+                        annot.startpos          = pos
+                        annot.endpos            = pos
+                        annot.startline         = line
+                        annot.startmulticomment = multicomment
+                        annot.startlinenumber   = linenumber
+                        allannots.append(annot)
+                    else:
+                        if annotkey in annotexp:
+                            table = annotexp[annotkey]
+                            if startend == "start":
+                                count      = 0
+                                hasdefined = 0
+                                # go over the table containing annotation
+                                while count < len(table):
+                                    infos = table[count]
+                                    # here we get if it's start or stop
+                                    state = infos['startend']
+                                    # It mean start is already defined
+                                    if state == 'start' or state == 'finish':
+                                        count += 1
+                                        continue
+                                    # Means that end
+                                    else:
+                                        annot = infos['annotation']
+
+                                        annot.startpos          = pos
+                                        annot.startline         = line
+                                        annot.startmulticomment = multicomment
+                                        annot.startlinenumber   = linenumber
+
+                                        allannots.append(annot)
+                                        infos['startend'] = 'finish'
+                                        hasdefined = 1
+                                        break
+                                # It means that annotation array has been running without finding an empty
+                                # case, a corresponding annotation in existing annotation
+                                if hasdefined == 0:
+                                    newinfos = {}
+                                    # It's just to define the thing
+                                    newinfos['startend'] = 'start'
+                                    annot = AnnotPair(
+                                        type       = type,
+                                        introntype = intron_type,
+                                        genename   = name,
+                                        direction  = arrow
+                                    )
+                                    annot.startpos          = pos
+                                    annot.startline         = line
+                                    annot.startmulticomment = multicomment
+                                    annot.startlinenumber   = linenumber
+
+                                    newinfos['annotation'] = annot
+                                    table.append(newinfos)
+                            else:
+                                count      = 0
+                                 # a variable that allows to
+                                hasdefined = 0
+                                # go over the table containing annotation
+                                while count < len(table):
+                                    infos = table[count]
+                                    # here we get if it's start or stop
+                                    state = infos['startend']
+                                    # It mean start is already defined
+                                    if state == 'end' or state == 'finish':
+                                        count += 1
+                                        continue
+                                    # Means that end
+                                    else:
+                                        annot = infos['annotation']
+                                        annot.endpos          = pos
+                                        annot.endline         = line
+                                        annot.endmulticomment = multicomment
+                                        annot.endlinenumber   = linenumber
+
+                                        allannots.append(annot)
+                                        infos['startend'] = 'finish'
+                                        hasdefined = 1
+                                        break
+                                # It means that annotation array has been running without finding an empty
+                                # case, a corresponding annotation in existing annotation
+                                if hasdefined == 0:
+                                    newinfos = {}
+                                    # It's just to define the thing
+                                    newinfos['startend'] = 'end'
+                                    annot = AnnotPair(
+                                        type       = type,
+                                        introntype = intron_type,
+                                        genename   = name,
+                                        direction  = arrow
+                                    )
+                                    annot.endpos          = pos
+                                    annot.endline         = line
+                                    annot.endmulticomment = multicomment
+                                    annot.endlinenumber   = linenumber
+
+                                    newinfos['annotation'] = annot
+                                    table.append(newinfos)
+                        else:
+                            annot =  AnnotPair(
+                                type       = type,
+                                introntype = intron_type,
+                                genename   = name,
+                                direction  = arrow,
+                            )
+                            if startend == "start":
+                                annot.startpos          = pos
+                                annot.startline         = line
+                                annot.startmulticomment = multicomment
+                                annot.startlinenumber   = linenumber
+                            if startend == "end":
+                                annot.endpos          = pos
+                                annot.endline         = line
+                                annot.endmulticomment = multicomment
+                                annot.endlinenumber   = linenumber
+                            # hash array containing, start stop, and the annot
+                            infos = {}
+                            # It's just to define the thing
+                            infos['startend']   = startend
+                            infos['annotation'] = annot
+                            table = []
+                            # we put the hashing table in the table
+                            table.append(infos)
+                            annotexp[annotkey] = table
+                    continue
+
+                if line.startswith(';'):
+                    multicomment = []
+                    while row < len(lines):
+                        if not lines[row].startswith(';') or not lines[row-1].endswith('\\'):
+                            row += 1
+                            break
+                        multicomment.append(lines[row])
+
+                    annot = AnnotPair(
+                        type              = "C",  # a comment
+                        startpos          = seqpos+1,
+                        startline         = line,
+                        startmulticomment = multicomment,
+                        startlinenumber   = linenumber,
+                    )
+
+                    allannots.append(annot)
+                    continue
+
+                raise ValueError(f"Unexpected line:\n{line}\n")
+
+            #  checking annotations
+            for annot in allannots:
+                if annot.type == 'G':
+                    # For the genename, deleting the _X : the number of each copy
+                    newgename = annot.genename
+                    newgename = re.sub(r'\_\d+', '', newgename)
+
+                    if re.match(r'-I\d+-(\S+)$', newgename):
+                        # special case for G-cox1_2-I3-orf232
+                        newgename = re.match(r'-I\d+-(\S+)$', newgename).group(1)
+
+                    annot.genename = newgename
+
+                    # If it's a gene
+                    if re.match(r'Sig-(.+)$', annot.genename):
+                        annot.genename = re.match(r'Sig-(.+)$', annot.genename).group(1)
+                        annot.type = "S"
+                    # If it's an exon
+                    elif re.match(r'-E\d+$', annot.genename) or re.match(r'-E\d+-\S+$', annot.genename):
+                        genenamecut = annot.genename.split("-")
+                        annot.genename = genenamecut[0] if genenamecut[0] != "" else annot.genename
+                        annot.type = "E"
+                    # If it's an intron
+                    elif re.match(r'-I\d+$', annot.genename) or re.match(r'-I\d+-\S+$', annot.genename):
+                        genenamecut = annot.genename.split("-")
+                        annot.genename = genenamecut[0] if genenamecut[0] != "" else annot.genename
+                        annot.type = "I"
+                    # If it's a tRNA
+                    elif re.match(r'trn[\w|?]*\([\w|?]*\)', annot.genename):
+                        annot.genename = re.match(r'trn([\w|?]*)\([\w|?]*\)', annot.genename).group(1)
+
+            annotexp = None
+            contig.sequence = seq
+
+            contig.annotations = allannots
+            seqlen = len(re.findall(r'[acgtACGTnN]', seq))
+            contig.sequencelength = seqlen
+
+            contigs.append(contig)
+        self.contigs = contigs
+        return self
+
+    def object_to_masterfile(self, filename):
+        # Print masterfile header
+        fh     = open(filename, 'w')
+        header = self.header or []
+
+        # Remove trailing blank lines
+        while len(header) and re.match(r'^\s*$', header[-1]):
+            header.pop()
+
+        if len(header):
+            fh.write("\n".join(header) + "\n")
+
+        contigs = self.contigs
+
+        for contig in contigs:
+            name         = contig.name
+            namecomments = contig.namecomments or ""
+
+            fh.write("\n\n")
+            fh.write(f">{name}{namecomments}\n")
+
+            posannots = []
+            annots    = contig.annotations
+            fullseq   = contig.sequence
+            start_ac  = {}
+            stop_ac   = {}
+
+            for annot in annots:
+                type  = annot.type
+                if type != 'AC':
+                    continue
+
+                start = annot.startpos
+                start_ac[start] = 1
+
+                stop = annot.endpos
+                stop_ac[stop] = 1
+
+            # num will be bio coords
+            num = 0
+            for i in range(len(fullseq)):
+                c = fullseq[i]
+                if c == '!':
+                    continue
+
+                # num is bio coords
+                num += 1
+
+                # See if start_ac[num] exists
+                if start_ac.get(num) or stop_ac.get(num):
+                    if fullseq[i-1] != '!' and start_ac.get(num):
+                        fullseq = fullseq[:i] + '!' + fullseq[i:]
+                        i += 1
+                    if fullseq[i] != '!' and stop_ac.get(num):
+                        fullseq = fullseq[:i+1] + '!' + fullseq[i+1:]
+                        i += 1
+
+            for annot in annots:
+                type  = annot.type
+                start = annot.startpos
+                if type == 'AC':
+                    continue
+
+                end   = annot.endpos
+                # <== or ==> or <==* or *==> or undef
+                arrow = annot.direction or ">"
+
+                if arrow.startswith('>'):
+                    if start:
+                        posannots.append([start-1, annot.startlinenumber or 0, "S", annot])
+                    if end:
+                        posannots.append([end, annot.endlinenumber or 0, "E", annot])
+                else:
+                    if start:
+                        posannots.append([start, annot.startlinenumber or 0, "S", annot])
+                    if end:
+                        posannots.append([end-1, annot.endlinenumber or 0, "E", annot])
+
+            key_sort_annots = functools.cmp_to_key(sort_annots)
+            posannots = sorted(posannots, key=key_sort_annots)
+
+            seqpos  = 0
+            charpos = 0
+            for annotinfo in posannots:
+                atpos, se, annot = annotinfo[0], annotinfo[2], annotinfo[3]
+                name = annot.genename
+
+                block    = ""
+                blockpos = seqpos
+                while seqpos < atpos:
+                    char  = fullseq[charpos]
+                    IsDef = 1 if not char else 0
+                    block += char
+                    charpos += 1
+                    if char != '!':
+                        seqpos += 1
+                if fullseq[charpos] == "!" and len(block) >= 4 and "!" in block[-4:]:
+                    block += "!"
+                    charpos += 1
+                if block:
+                    fasta_block_to_fh(block, blockpos+1, fh)
+
+                multicomment = [];
+                if se == "S":
+                    fh.write(f"{annot.startline}\n")
+                    multicomment = annot.startmulticomment
+                else:
+                    fh.write(f"{annot.endline}\n")
+                    multicomment = annot.endmulticomment
+                if multicomment:
+                    fh.write("\n".join(multicomment) + "\n")
+
+            block = ""
+            if charpos < len(fullseq):
+                block = fullseq[charpos:]
+            else:
+                block = ""
+
+            if block:
+                fasta_block_to_fh(block, seqpos+1, fh)
+
+        fh.close()
+
+    # Utility routine that precomputes an internal hash the first
+    # time it's called.
+    def get_contig_by_name(self, contigname):
+        if not self['!contigbyname!']:
+            cache   = self['!contigbyname!'] = {}
+            contigs = self.contigs or []
+            for contig in contigs:
+                name = contig.name
+                if name:
+                    cache[name] = contig
+
+        self['!contigbyname!'][contigname]  # returns undef if not found.
+
+
+    def sort_masterfile(self, direction):
+        contigs = self.contigs
+        contigs = sorted(contigs, key=lambda x: len(x.sequence), reverse=(direction == 1))

--- a/PirModels/masterfile/masterfile_contig.py
+++ b/PirModels/masterfile/masterfile_contig.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+from annot_pair import AnnotPair
+
+class MasterfileContig:
+    def __init__(self):
+        self.name         = None
+        self.uniq_name    = None
+        self.genetic_code = None
+        self.namecomments = None
+        self.annotations  = []
+
+    def add_annot_pair(self, annot_pair):
+        self.annot_pairs.append(annot_pair)
+

--- a/PirModels/mfannot_external_progs/__init__.py
+++ b/PirModels/mfannot_external_progs/__init__.py
@@ -1,0 +1,3 @@
+from .mfannot_external_progs   import MFannotExternalProgs
+from .mfannot_gene_command_set import MFannotGeneCommandSet
+from .mfannot_gene_commands    import MFannotGeneCommands

--- a/PirModels/mfannot_external_progs/mfannot_external_progs.py
+++ b/PirModels/mfannot_external_progs/mfannot_external_progs.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+
+import re
+from mfannot_gene_command_set import MFannotGeneCommandSet
+from mfannot_gene_commands    import MFannotGeneCommands
+
+#
+# This class represents the content of a configuration
+# file used by mfannot; that file stores a list of external
+# programs (with their arguments) that are used to add
+# further annotations; the output of the programs are
+# expected to be a series of XML documents of type
+# AnnotPairCollection.
+#
+# Sample format of text file
+#
+# # comment
+# GeneName=rnl
+# PerContig=true        # optional line; not yet implemented
+# PreCommands           # optional block
+#   blah blah blah line 1
+#   blah blah blah line 2
+# EndCommands
+# Commands                 # one or many such blocks
+#   blah blah blah line 1
+#   blah blah blah line 2
+# EndCommands
+# Postcommands          # optional block
+#   blah blah blah line 1
+#   blah blah blah line 2
+# EndCommands
+#
+
+class MFannotExternalProgs:
+    def __init__(self):
+        self.filename  = None
+        self.geneprogs = {}
+
+    def import_from_text_file(self, filename):
+        self.filename = filename
+
+        lines = []
+        with open(filename, 'r') as f:
+            line = f.readlines()
+            f.close()
+
+        filerank = 0
+        genecoms = {}
+
+        lines    = []
+        with open(filename, 'r') as file:
+            lines = file.readlines()  # Read all lines into a list
+
+
+        while lines:
+            line = lines.pop(0)
+            if not line.strip() or line.strip().startswith('#'):
+                continue
+
+            # Expects "genename"
+            genename_match = re.match(r'^\s*genenames?\s*=\s*(\w+(\s*,\s*\w+)*)\s*$', line, re.IGNORECASE)
+            if not genename_match:
+                raise ValueError(f"Error: unparsable line in '{filename}' (expected \"genename=\"), got:\n{line}")
+
+            # potentially a list, like "abc,def"
+            genename = genename_match.group(1)
+            genename = re.sub(r'\s+', '', genename)
+            if genename in genecoms:
+                raise ValueError(f"Error: genename '{genename}' seen more than once in file '{filename}'.")
+
+            genecom            = MFannotGeneCommandSet()
+            genecom.genename   = genename
+            genecom.filerank   = filerank
+            genecom.commandset = {}
+
+            commandset         = genecom.commandset
+
+            match_ignore = re.match(r'^\s*$|^\s*#', line)
+            while lines and match_ignore:
+                lines.pop(0)
+
+            # Parse other optional fields (right now, only "percontig")
+            optional_match = re.match(r'^\s*(percontig|otherkeyTODO)\s*=\s*(\S+)\s*$', line, re.IGNORECASE)
+            while lines and optional_match:
+                key = optional_match.group(1)
+                val = optional_match.group(2)
+                # boolean fields
+                bool_match = re.match(r'^(|f|false|0|no|n)$', val, re.IGNORECASE)
+                if bool_match:
+                    val = 0
+                else:
+                    val = 1
+                key = key.lower()
+                genecom.__dict__[key] = val
+
+                match_ignore = re.match(r'^\s*$|^\s*#', file[0])
+                while lines and match_ignore:
+                    lines.pop(0)
+
+            command_counter = 0
+            while lines:
+                line = lines.pop(0)
+                while lines and re.match(r'^\s*$|^\s*#', line):
+                    line = lines.pop(0)
+                if not lines:
+                    break
+
+                blocktype_match = re.match(r'^\s*(pre|post)?commands\s*$', line, re.IGNORECASE)
+                if not blocktype_match:
+                    continue
+                blocktype = blocktype_match.group(1) or ''
+                blocktype = blocktype.lower()
+                line = lines.pop(0)
+
+                coms = []
+                # read commands until "endcommands"
+                while lines and not re.match(r'^\s*endcommands\s*$', line, re.IGNORECASE):
+                    line = line.rstrip()
+                    # make sure continuation lines don't have trailing blanks
+                    if re.match(r'#\\\s+$', line):
+                        line = re.sub(r'\s+$', '', line)
+                    coms.append(line)
+                    line = lines.pop(0)
+
+                # Create command object
+                command_obj              = MFannotGeneCommands()
+                command_obj.genename     = genename
+                command_obj.bashcommands = coms
+
+                command_key = None
+                if blocktype:
+                    command_key = blocktype
+                else:
+                    command_key      = str(command_counter)
+                    command_counter += 1
+
+                if command_key in commandset:
+                    raise ValueError(f"Error in '{filename}': duplicate command block '{command_key}' for gene '{genename}'.")
+
+                if not coms or all(re.match(r'^\s*$|^\s*#', com) for com in coms):
+                    raise ValueError(f"Error in '{filename}', gene '{genename}', command block '{command_key}': all commands are blank?!?")
+
+                # Exception if all items in coms are blank
+                # XXXXX TODO: need to be tested XXXXX
+                if not coms or all(re.match(r'^\s*$|^\s*#', com) for com in coms):
+                    raise ValueError(f"Error in '{filename}', gene '{genename}', command block '{command_key}': all commands are blank?!?")
+
+                commandset[command_key] = command_obj
+
+                if not lines:
+                    lines.insert(0, "(EOF)\n") # for error messages
+
+                if not re.match(r'^\s*endcommands\s*$', line, re.IGNORECASE):
+                    raise ValueError(f"Error: unparsable line in '{filename}' (expected \"endcommands\" keyword), got:\n{line}")
+
+                if lines and not "0" in commandset:
+                    raise ValueError(f"Error in '{filename}': unparsable line in '{genename}':\n{line}\n")
+
+                genecoms[genename] = genecom
+                break
+
+        self.geneprogs = genecoms

--- a/PirModels/mfannot_external_progs/mfannot_gene_command_set.py
+++ b/PirModels/mfannot_external_progs/mfannot_gene_command_set.py
@@ -1,0 +1,71 @@
+#! /usr/bin/env python3
+
+import os
+
+#
+# This class represents the content of a configuration
+# file used by mfannot; that file stores a list of external
+# programs (with their arguments) that are used to add
+# further annotations; the output of the programs are
+# expected to be a series of XML documents of type
+# AnnotPairCollection.
+#
+
+class MFannotGeneCommandSet:
+    def __init__(self):
+        self.debug       = False
+        self.genename    = None
+        self.percontig   = None
+        self.filerank    = None
+        self.commandset  = {}
+
+    def set_debug(self, debug_value):
+        if not debug_value:
+            return self.debug
+        commandset = self.commandset
+        for genecom in commandset.values():
+            genecom.debug = debug_value
+        self.debug = debug_value
+
+    def execute(self, cwd, tmp_dir, substitutions):
+        # cwd           == working directory
+        # tmp_dir       == where we can create temp files
+        # substitutions == hash VAR => val to substitute in place of the string %VAR% in bashcommands
+
+        # if cwd is not a valid directory, raise an error
+        if not cwd or not os.path.isdir(cwd):
+            raise ValueError(f"Error: no valid CWD supplied for Execute()... got '{cwd}'.")
+        # if tmp_dir is not a valid directory, raise an error
+        if not tmp_dir or not os.path.isdir(tmp_dir):
+            raise ValueError(f"Error: no valid TMPDIR supplied for Execute()... got '{tmp_dir}'.")
+
+        debug = self.debug or False
+
+        commandset  = self.commandset
+        commandkeys = sorted([key for key in commandset.keys() if key.isdigit()])
+
+        outfilename = substitutions["OUTFILE"] or ""
+        foundoutfile = False
+        outcapt     = "(none)"
+        errcapt     = "(none)"
+
+        for commandkey in ["pre", *commandkeys, "post"]:
+            genecom = commandset[commandkey] if commandkey in commandset else None
+            if not genecom:
+                continue
+            if foundoutfile and commandkey.isdigit():
+                continue
+
+            commandlabel = ""
+            if commandkey == "pre":
+                commandlabel = "A-Pre"
+            elif commandkey == "post":
+                commandlabel = "C-Post"
+            else:
+                commandlabel = f"B-{commandkey}"
+
+            outcapt, errcapt = genecom.execute(cwd, tmp_dir, substitutions, commandlabel)
+            if os.path.isfile(outfilename) and os.path.getsize(outfilename) > 0:
+                foundoutfile = True
+
+        return outcapt, errcapt

--- a/PirModels/mfannot_external_progs/mfannot_gene_commands.py
+++ b/PirModels/mfannot_external_progs/mfannot_gene_commands.py
@@ -1,0 +1,94 @@
+# !/usr/bin/env python3
+
+import sys
+import os
+import subprocess
+
+#####################################################################
+# Utility functions                                                 #
+#####################################################################
+
+def check_path(bashscript, searchfor, val):
+    each_string = bashscript.split()
+    for string in each_string:
+        if searchfor not in string:
+            continue
+        string = string.replace(searchfor, val)
+        if not os.path.exists(string) or not os.path.isfile(string):
+            raise ValueError(f"Model file '{string}' doesn't exist or isn't readable.\nCheck installation of mfannot_models (see INSTALL.txt).")
+
+#####################################################################
+# MFannotGeneCommands class                                         #
+#                                                                   #
+# This class represents a single group of commands.                 #
+#                                                                   #
+# See also the encapsulating object, <MfAnnotCommandSet>            #
+#####################################################################
+
+class MFannotGeneCommands:
+    def __init__(self):
+        self.debug        = False
+        self.genename     = None
+        self.bashcommands = []
+
+    def execute(self, cwd, tmp_dir, substitutions, commandlabel):
+        if not cwd:
+            raise ValueError("Error: no valid CWD supplied for Execute()... got '%s'." % cwd)
+        if not tmp_dir:
+            raise ValueError("Error: no valid TMP_DIR supplied for Execute()... got '%s'." % tmp_dir)
+
+        debug        = self.debug
+        genename     = substitutions["GENENAME"] or self.genename or "unk"
+
+        bashcommands = self.bashcommands
+        bashscript   = "\n".join(bashcommands) + "\n"
+
+        # make copy; we will add some values right now
+        moresubs             = substitutions.copy()
+        if "GENENAME" not in moresubs:
+            moresubs["GENENAME"] = genename
+        if "DEBUG" not in moresubs:
+            moresubs["DEBUG"] = "#" if debug else ""
+
+        for var, val in moresubs.items():
+            val = str(val)
+
+            if not var.isalpha():
+                raise ValueError("Not a proper variable name '%s'." % var)
+
+            searchfor = "%" + var + "%"
+            if bashscript.find(searchfor) >= 0 and var == "MODPATH":
+                check_path(bashscript, searchfor, val)
+
+            bashscript = bashscript.replace(searchfor, val)
+
+        pid     = os.getpid()
+        script  = "%s/bashcom.%s.%s.MfGC.%s" % (tmp_dir, genename, commandlabel, pid)
+        outcapt = "%s/out.%s.%s.MfGC.%s"     % (tmp_dir, genename, commandlabel, pid)
+        errcapt = "%s/err.%s.%s.MfGC.%s"     % (tmp_dir, genename, commandlabel, pid)
+
+        # Write the script
+        with open(script, "w") as ofh:
+            ofh.write("#!/bin/bash\n")
+            ofh.write("\n")
+            ofh.write("# This script created automatically for gene '%s' (block '%s').\n" % (genename, commandlabel))
+            ofh.write("\n")
+            ofh.write(bashscript)
+        ofh.close()
+
+        command = "cd '%s';/bin/bash '%s' >'%s' 2>'%s'" % (cwd, script, outcapt, errcapt)
+
+        if debug:
+            debug_text  = "# DEBUG: Executing external script block '%s' for '%s'.\n" % (commandlabel, genename)
+            debug_text += "# --- COMMAND : %s\n" % command
+            debug_text += "# --- SCRIPT %s START ---\n" % script
+            debug_text += bashscript
+            debug_text += "\n"
+            debug_text += "# --- SCRIPT %s END ---\n" % script
+
+            sys.stderr.write(debug_text)
+
+        subprocess.run(command, shell=True, check=True)
+
+        return (outcapt, errcapt)
+

--- a/hmmannot_lib/annotate_using_external_programs.py
+++ b/hmmannot_lib/annotate_using_external_programs.py
@@ -1,0 +1,144 @@
+# TODO: document
+
+import os
+from PirModels.mfannot_external_progs import MFannotExternalProgs
+
+
+#####################################################################
+# Utility functions                                                 #
+#####################################################################
+
+# Create a file for each contig
+def create_contig_file(tmp_dir, pirmaster):
+    # Create a directory to store the contigs
+    contigs_dir = f"{tmp_dir}/Contigs"
+    if not os.path.isdir(contigs_dir):
+        os.mkdir(contigs_dir, 0o700)
+
+    contigs = pirmaster.contigs
+    for contig in contigs:
+        seq       = contig.sequence.upper()
+        seq       = seq.replace("!", "")
+        name      = contig.name
+
+        contig_file = f"{contigs_dir}/{name}.fna"
+        with open(contig_file, "w") as CF:
+            CF.write(f">{name}\n{seq}\n")
+
+        CF.close()
+
+# Sort the external programs by their filerank
+def sorted_external_progs(mfannot_external_progs):
+    # Retrieve all keys from the geneprogs dictionary
+    keys = mfannot_external_progs.geneprogs.keys()
+
+    # Define the sorting key using a lambda function
+    sorting_key = lambda x: mfannot_external_progs.geneprogs[x].filerank
+
+    # Sort the keys based on the filerank attribute
+    sorted_keys = sorted(keys, key=sorting_key)
+
+    # Return the sorted list of keys
+    return sorted_keys
+
+# Execute an external program
+def execute_external_program(tmp_dir, genename, model_path, plainmasterfile, gencode, debug, commandobject, outfile):
+
+    substitutions = {
+        "OUTFILE":        outfile,                  # What will be created, a series of AnnotPairCollections
+        "MODPATH":        model_path,
+        "PLAINFASTAFILE": plainmasterfile,
+        "TMPDIR":         tmp_dir,                  # Mfannot's tmp dir
+        "GENENAME":       genename,                 # Optional; the Execute command use this but you can override it yourself)
+        "GENCODE":        gencode,
+        "DEBUG":          "#" if debug else "",     # See the config file text
+    }
+
+    commandobject.set_debug(debug)
+    out_and_err_dir = f"{os.path.dirname(outfile)}/err_out"
+    if not os.path.isdir(out_and_err_dir):
+        os.mkdir(out_and_err_dir)
+    outfile, errfile = commandobject.execute(out_and_err_dir, out_and_err_dir, substitutions)
+
+    # TODO: Read back the AnnotPairCollections
+    # Read back AnnotPairCollections;
+    # with open(outfile_gene, "r") as infh:
+        # annotpaircollections = PirObject.file_handle_to_object(infh)
+    annotpaircollections = []
+
+    return annotpaircollections
+
+#####################################################################
+# Main function                                                     #
+#####################################################################
+
+# Annotate the contigs using external programs
+# This function is called from HMMannot.py
+#
+# The function reads the configuration file and parses the external programs
+# to be executed. It then runs each external program command set.
+#
+def annotate_using_external_programs(conf_file, tmp_dir, pirmaster, masterfile, gencode, model_path, debug, *ext_selected):
+    ext_selected = ext_selected or None
+
+    mfannot_external_progs = MFannotExternalProgs()
+    mfannot_external_progs.import_from_text_file(conf_file)
+
+    # Here we build a list of external programs to run; by default all
+    # of them are executed, but this can be modified by the option --ext_select, which
+    # we parse here.
+
+    # Create one file per contig
+    work_dir = f"{tmp_dir}/Contigs"
+    if not os.path.isdir(work_dir):
+        create_contig_file(tmp_dir, pirmaster)
+
+    # Default: all of them
+    allprogs     = [prog for prog in mfannot_external_progs.geneprogs.keys()]
+    allprogs     = {prog.lower(): 1 for prog in allprogs}
+    progs_to_run = {prog.lower(): 1 for prog in allprogs}
+
+    # What do we have in --ext_select? Parse it
+    if ext_selected == "all":
+        ext_selected = ""
+
+    no_ext = [ext for ext in ext_selected if ext.startswith("no")]
+    if no_ext:
+        # There are some 'no', which means ( ALL minus the 'no's )
+        for noext in no_ext:
+            noext = noext[2:]
+            del progs_to_run[noext.lower()]
+    elif ext_selected:
+        # There are no 'nos', which means --ext_select is the full list
+        progs_to_run = {ext.lower(): 1 for ext in ext_selected}
+
+    # Print warnings about unknown names in --ext_select
+    for prog in progs_to_run:
+        if prog == "none":
+            continue
+        if prog not in allprogs:
+            print(f"Warning: unknown external program '{prog}' in '{conf_file}'")
+
+    # Run each external program command set.
+    # Now sorted; these are keys with possible MULTIPLE names, e.g. "rns,rnl"
+    extcomsets = sorted_external_progs(mfannot_external_progs)
+
+    dir_dict = {filename: os.path.join(work_dir, filename) for filename in os.listdir(work_dir)}
+    for comsetnames in extcomsets:
+        for genename in comsetnames.split(","):
+            if genename.lower() not in progs_to_run:
+                continue
+            if genename.lower() != "intronI".lower() and genename.lower() != "intronII".lower():
+                if not debug:
+                    print(f"    '{genename}'...\n")
+            for filename in dir_dict:
+                if filename.startswith(".") or filename.endswith(".xml") or not os.path.isfile(os.path.join(work_dir, filename)):
+                    continue
+                commandobject = mfannot_external_progs.geneprogs[comsetnames]
+                mf            = os.path.join(work_dir, filename)
+                out           = f"{mf}-{genename}.xml"
+
+                APC           = execute_external_program(tmp_dir, genename, model_path, mf, gencode, debug, commandobject, out)
+                # TODO: Implement the following functions
+                # &ReconstructFullRNA($genename,$APC) if $genename eq "rns" || $genename eq "rnl";
+                # &AnnotateFromExternalAPC($genename,$APC);


### PR DESCRIPTION
It add the following: 
  - Some options
  -  Check if some dir/files exist (MFANNOT_MOD_PATH, HMM_models)
  - Add `annotate_using_external_programs`. 
  
  *Note*: `annotate_using_external_programs`: 
  - It parse the [MFANNOT_MOD_PATH/.mfannot_external_programs.conf](https://github.com/BFL-lab/MFannot_data/blob/master/config/.mfannot_external_programs.conf)
  - It implement the 3 following PirModels: 
      - [MfAnnotExternalProgs.pir](https://github.com/BFL-lab/PirModels/blob/master/MfAnnotExternalProgs.pir)
      - [MfAnnotGeneCommandSet.pir](https://github.com/BFL-lab/PirModels/blob/master/MfAnnotGeneCommandSet.pir)
      - [MfAnnotGeneCommands.pir](https://github.com/BFL-lab/PirModels/blob/master/MfAnnotGeneCommands.pir)
      
 For now it only run the external program for `IntronI` and `IntronII`, the external program will generate a list of `AnnotPair` stored in an `AnnotPairCollection`. For example: 
 
 ```
 <AnnotPairCollection>
  <genename>IntronII</genename>
  <contigname>contig1</contigname>
  <annotpairlist struct="array" type="AnnotPair">
    <AnnotPair>
      <type>I</type>
      <genename>comment</genename>
      <startpos>26780</startpos>
      <endpos>26822</endpos>
      <direction>==&gt;</direction>
      <startline>;; mfannot:     /group=II (5.16e-13)</startline>
      <endline>;; mfannot:</endline>
      <score>5.16e-13</score>
      <idbyRNA>1</idbyRNA>
    </AnnotPair>
  </annotpairlist>
</AnnotPairCollection>
``` 

*Note*: I put some `TODO` section for clarity. Next step is implemt the `AnnotateFromExternalAPC` in order to integrate the `AnnotPair` into the new annotated masterfile. 
